### PR TITLE
Filtering internal timescaledb tables, views, and routines

### DIFF
--- a/plugins/dbgate-plugin-postgres/src/backend/sql/routines.js
+++ b/plugins/dbgate-plugin-postgres/src/backend/sql/routines.js
@@ -8,7 +8,7 @@ select
   data_type as "data_type",
   external_language as "language"
 from
-  information_schema.routines where routine_schema != 'information_schema' and routine_schema != 'pg_catalog' 
+  information_schema.routines where routine_schema != 'information_schema' and routine_schema != 'pg_catalog' and routine_schema NOT LIKE '%_timescaledb%'
   and (
    (routine_type = 'PROCEDURE' and ('procedures:' || routine_schema || '.' ||  routine_name) =OBJECT_ID_CONDITION)
    or

--- a/plugins/dbgate-plugin-postgres/src/backend/sql/tableList.js
+++ b/plugins/dbgate-plugin-postgres/src/backend/sql/tableList.js
@@ -7,4 +7,5 @@ and infoTables.table_schema <> 'pg_catalog'
 and infoTables.table_schema <> 'information_schema'
 and infoTables.table_schema <> 'pg_internal'
 and infoTables.table_schema !~ '^pg_toast'
+and infoTables.table_schema NOT LIKE '%_timescaledb%'
 `;

--- a/plugins/dbgate-plugin-postgres/src/backend/sql/tableModifications.js
+++ b/plugins/dbgate-plugin-postgres/src/backend/sql/tableModifications.js
@@ -25,4 +25,5 @@ and infoTables.table_schema <> 'pg_catalog'
 and infoTables.table_schema <> 'information_schema'
 and infoTables.table_schema <> 'pg_internal'
 and infoTables.table_schema !~ '^pg_toast'
+and infoTables.table_schema NOT LIKE '%_timescaledb%'
 `;

--- a/plugins/dbgate-plugin-postgres/src/backend/sql/views.js
+++ b/plugins/dbgate-plugin-postgres/src/backend/sql/views.js
@@ -6,6 +6,6 @@ select
   md5(view_definition) as "hash_code"
 from
   information_schema.views 
-where table_schema != 'information_schema' and table_schema != 'pg_catalog'
+where table_schema != 'information_schema' and table_schema != 'pg_catalog' and table_schema NOT LIKE '%_timescaledb%'
   and ('views:' || table_schema || '.' ||  table_name) =OBJECT_ID_CONDITION
 `;


### PR DESCRIPTION
Timescaledb creates many internal database objects if a postgres table has the extension enabled. The number of these objects (especially tables) increase drastically as more data is stored, to the point that the table view fails to load and no tables (timescaledb or not) are viewable.

This change filters out all of these timescaledb specific internal objects (any timescaledb schema prefixed with an underscore) which the user will never care about. In addition to fixing the table view not loading, this removes unnecessary clutter from views and routines.

<img width="388" alt="Screenshot 2024-06-21 at 15 26 26" src="https://github.com/Vandebron/dbgate/assets/121795724/c3418415-9132-4e88-9efc-3c2c294d624d">



branch:timescaledb-filtering